### PR TITLE
feat: 알림 페이지 UI 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,6 +45,8 @@
   --color-element: var(--element);
   --color-light: var(--light);
   --color-medium: var(--medium);
+  --color-green: var(--green);
+  --color-gray-green: var(--gray-green);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -100,6 +102,10 @@
   /* 테두리 색상 */
   --light: #dee2e6;
   --medium: #adb5bd;
+
+  /* 초록색 */
+  --green: #12b886;
+  --gray-green: #e9f3f2;
 }
 
 .dark {

--- a/src/app/notifications/layout.tsx
+++ b/src/app/notifications/layout.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import MainContent from "@/components/common/main-content";
+import ActionButton from "@/components/notifications/ActionButton";
+import ReadFilterButton from "@/components/notifications/ReadFilterButton";
+
+export default function NotificationsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const handleMarkAllAsRead = () => {
+    // TODO: 모두 읽음 API 호출
+  };
+
+  const handleDeleteAll = () => {
+    // TODO: 모두 삭제 API 호출
+  };
+
+  return (
+    <MainContent>
+      <div className="flex flex-col gap-4">
+        <h1 className="text-3xl font-bold">알림</h1>
+        <div className="flex justify-between">
+          <div className="flex gap-3">
+            <ReadFilterButton href="/notifications">전체</ReadFilterButton>
+            <ReadFilterButton href="/notifications/not-read">
+              읽지 않음
+            </ReadFilterButton>
+          </div>
+          <div className="flex gap-2 text-sm text-tertiary">
+            <ActionButton onClick={handleMarkAllAsRead}>모두 읽음</ActionButton>
+            <ActionButton onClick={handleDeleteAll}>모두 삭제</ActionButton>
+          </div>
+        </div>
+        {children}
+      </div>
+    </MainContent>
+  );
+}

--- a/src/app/notifications/not-read/page.tsx
+++ b/src/app/notifications/not-read/page.tsx
@@ -1,0 +1,3 @@
+export default function NotReadPage() {
+  return <div>NotReadPage</div>;
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,3 @@
+export default function NotificationsPage() {
+  return <div>NotificationsPage</div>;
+}

--- a/src/components/common/main-content.tsx
+++ b/src/components/common/main-content.tsx
@@ -1,0 +1,11 @@
+interface MainContentProps {
+  children: React.ReactNode;
+}
+
+export default function MainContent({ children }: MainContentProps) {
+  return (
+    <div className="flex flex-col gap-4 mt-30 mx-auto max-w-screen-md">
+      {children}
+    </div>
+  );
+}

--- a/src/components/notifications/ActionButton.tsx
+++ b/src/components/notifications/ActionButton.tsx
@@ -1,0 +1,12 @@
+interface ActionButtonProps {
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+export default function ActionButton({ onClick, children }: ActionButtonProps) {
+  return (
+    <button onClick={onClick} className="cursor-pointer hover:text-primary">
+      {children}
+    </button>
+  );
+}

--- a/src/components/notifications/ReadFilterButton.tsx
+++ b/src/components/notifications/ReadFilterButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface ReadFilterButtonProps {
+  href: string;
+  children: React.ReactNode;
+}
+
+export default function ReadFilterButton({
+  href,
+  children,
+}: ReadFilterButtonProps) {
+  const pathname = usePathname();
+
+  const isActive = pathname === href;
+  const baseStyle =
+    "text-md px-4 py-2 rounded-2xl font-semibold cursor-pointer";
+  const activeStyle = "bg-gray-green text-green";
+  const inactiveStyle = "bg-gray-100 text-tertiary";
+
+  return (
+    <Link
+      href={href}
+      className={`${baseStyle} ${isActive ? activeStyle : inactiveStyle}`}
+    >
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## 📋 변경 사항

- 알림 페이지의 전체 / 읽지 않음 각각 라우팅 별 UI가 같기 때문에 layout에 공통으로 구현
- 각 라우팅 /notifications, /notifications/not-read
- 전체 / 읽지 않음 버튼 UI 구현
- globals.css에 초록색 관련 색상 변수 추가

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [x] 🎨 design: UI/UX 디자인 변경
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정
- [ ] 🎨 style: 코드 포맷팅 (기능 변경 없음)

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

<img width="1494" height="815" alt="스크린샷 2025-07-14 오후 5 14 38" src="https://github.com/user-attachments/assets/b1180c6d-b9f4-4a04-8962-70a439536c18" />

## 🔗 관련 이슈

#7 

- Closes #7 
